### PR TITLE
saving session to persistence when LoadSessions is called

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -18,7 +18,7 @@ import { Home } from '@material-ui/icons'
 import shuffle from 'lodash.shuffle'
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 
-import { getAllSessions, saveAllSessions } from './shared/persistence'
+import { getAllSessions } from './shared/persistence'
 import * as sessionService from './shared/sessionService'
 import NewSession from './NewSession'
 import SessionsList from './SessionsList'
@@ -53,16 +53,6 @@ function App() {
     const payload = { sessionId, faction, points }
     comboDispatch({ type: 'VictoryPointsUpdated', payload })
   }, [comboDispatch])
-
-  useEffect(() => {
-    async function save() {
-      saveAllSessions(sessions.data)
-    }
-
-    save()
-
-    return save
-  }, [sessions]);
 
   useEffect(() => {
     const sessions = getAllSessions()

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { saveAllSessions } from './shared/persistence'
+
 export const StateContext = React.createContext();
 export const ComboDispatchContext = React.createContext();
 export const DispatchContext = React.createContext();
@@ -23,6 +25,7 @@ export const init = () => {
 export const reducer = (state, action) => {
   switch (action.type) {
     case 'LoadSessions':
+      saveAllSessions(action.sessions)
       return {
         ...state,
         sessions: {


### PR DESCRIPTION
previously, empty sessions from default state would overwrite your saved sessions in local storage

now it doesn't happen and all your visited sessions are saved on the list