### PR TITLE
Validate number of factions in game session #10

### DIFF
--- a/client/src/SessionSetup/SetFactions.js
+++ b/client/src/SessionSetup/SetFactions.js
@@ -40,6 +40,11 @@ export function SetFactions({ dispatch }) {
   const classes = useStyles()
 
   const [selectedFactions, setSelected] = useState([])
+
+  const validateSelectedFactionsLength = useCallback(
+    () => selectedFactions.length >= 2 && selectedFactions.length <= 8
+  )
+
   const isSelected = useCallback(
     (factionKey) => selectedFactions.includes(factionKey),
     [selectedFactions],
@@ -110,7 +115,7 @@ export function SetFactions({ dispatch }) {
           aria-label="add"
           className={classes.fab}
           color="secondary"
-          disabled={!selectedFactions.length}
+          disabled={!validateSelectedFactionsLength()}
           onClick={openPasswordProtectionDialog}
         >
           <Check />

--- a/client/src/SessionView/Overview/FactionNutshell.js
+++ b/client/src/SessionView/Overview/FactionNutshell.js
@@ -4,6 +4,7 @@ import {
   Card,
   CardContent,
   CardActions,
+  CardMedia,
 } from '@material-ui/core'
 import { LocalLibrary, PhotoLibrary } from '@material-ui/icons'
 import { useTranslation } from 'react-i18next'
@@ -15,16 +16,16 @@ export function FactionNutshell({ onClose, factionKey }) {
   const factionName = factionKey ? t(`factions.${factionKey}.name`) : ''
 
   return (
-    <Dialog maxWidth="lg" onClose={onClose} open={factionKey !== null}>
+    <Dialog maxWidth="xs" onClose={onClose} open={factionKey !== null}>
       {factionKey && (
         <Card>
-          <CardContent>
-            <img
+           <CardMedia
+              component="img"
+              height="300"
               alt={factionKey}
-              src={getFactionCheatSheetPath(factionKey)}
+              image={getFactionCheatSheetPath(factionKey)}
               title={factionName}
             />
-          </CardContent>
           <CardActions disableSpacing>
             <Button
               aria-label={t('sessionView.overview.goToWiki')}


### PR DESCRIPTION
Simple change from checking !selectedFactions.lenght in template to const.
I think 2-8 players is best decition right now, since there's unofficial princess variant (for 2 players) and only 8 strategy Cards.
We should consider moving this to external env or properties since in template in Draftsetup.js there's similiar hardcoded min, max values for that.