### PR TITLE
loading session from backend every time it is accessed

### DIFF
--- a/client/src/SessionView/index.js
+++ b/client/src/SessionView/index.js
@@ -17,6 +17,10 @@ function Thing({ children }) {
     setSecret(state.secret)
   }
 
+  if (session.error) {
+    return <p>{session.error}</p>
+  }
+
   return (
     <SessionView
       editable={editable}

--- a/client/src/SessionsList.js
+++ b/client/src/SessionsList.js
@@ -3,7 +3,6 @@ import {
   Chip,
   Grid,
   CircularProgress,
-  Fab,
   List,
   ListItem,
   ListItemIcon,
@@ -13,7 +12,6 @@ import {
 } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import {
-  Add,
   EditOutlined,
   Lock,
   Done,


### PR DESCRIPTION
this fixes a bug where session structure changes and the application tries to load it from local storage and crashes

(it would be better still to load this data by react-query but let's pay this tech debt step by step this as a tech debt task)