### PR TITLE
move edit prompt to top center

### DIFF
--- a/client/src/SessionView/EditButton/EditPrompt.js
+++ b/client/src/SessionView/EditButton/EditPrompt.js
@@ -73,8 +73,8 @@ export function EditPromptProvider() {
         </>
       }
       anchorOrigin={{
-        vertical: 'bottom',
-        horizontal: 'left',
+        vertical: 'top',
+        horizontal: 'center',
       }}
       autoHideDuration={3000}
       message="To make changes you have to "


### PR DESCRIPTION
#197 
move prompt to top center because chat icon obscures it