### PR TITLE
200 draft results shortcut

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash.debounce": "^4.0.8",
     "lodash.shuffle": "^4.2.0",
+    "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dnd": "^14.0.3",
     "react-dnd-touch-backend": "^14.1.0",

--- a/client/src/SessionView/Overview/DraftSummaryDialog.js
+++ b/client/src/SessionView/Overview/DraftSummaryDialog.js
@@ -1,0 +1,31 @@
+import { useCallback, useMemo } from 'react'
+import { Dialog } from '@material-ui/core'
+
+import { DraftSummaryTable } from '../components'
+import { useSessionContext } from '../useSessionContext'
+
+export function DraftSummaryDialog({ open, set }) {
+  const { session } = useSessionContext()
+
+  const closeDialog = useCallback(() => set(false), [set])
+
+  const picks = useMemo(
+    () =>
+      session.players.map((player, index) => ({
+        ...player,
+        tablePosition: index,
+      })),
+    [session.players],
+  )
+
+  return (
+    <Dialog onClose={closeDialog} open={open}>
+      <DraftSummaryTable
+        map={session.map}
+        picks={picks}
+        speaker={session.draft.speaker}
+        withTablePositions={Boolean(session.setup?.options?.tablePick)}
+      />
+    </Dialog>
+  )
+}

--- a/client/src/SessionView/Overview/Drafting/Drafting.js
+++ b/client/src/SessionView/Overview/Drafting/Drafting.js
@@ -6,7 +6,7 @@ import shuffle from 'lodash.shuffle'
 import { makeStyles } from '@material-ui/core/styles'
 import clsx from 'clsx'
 
-import { MapPreview } from '../../MapPreview'
+import { MapPreview } from '../../components'
 import { useDomainErrors } from '../../../shared/errorHandling'
 import { SessionNutshell } from '../SessionNutshell'
 import { EditPrompt } from '../../Edit'
@@ -395,7 +395,7 @@ export function Drafting({ editable, session, sessionService }) {
         )}
       </Box>
       <Box align="center" mb={2}>
-        <MapPreview session={session} />
+        <MapPreview map={session.map} />
       </Box>
       {draft.phase === PHASE.speaker && <Typography>picks:</Typography>}
       {session.setup.options.tablePick && draft.phase === PHASE.speaker && (

--- a/client/src/SessionView/Overview/FactionNutshells.js
+++ b/client/src/SessionView/Overview/FactionNutshells.js
@@ -10,19 +10,28 @@ import {
   Tooltip,
 } from '@material-ui/core'
 import { Link, generatePath } from 'react-router-dom'
-import { LocalLibrary, PhotoLibrary } from '@material-ui/icons'
+import { LocalLibrary, PhotoLibrary, Info } from '@material-ui/icons'
 import { useTranslation, Trans } from 'react-i18next'
 
 import { SESSION_VIEW_ROUTES } from '../../shared/constants'
 import * as factions from '../../gameInfo/factions'
 
 import { FactionNutshell } from './FactionNutshell'
+import { DraftSummaryDialog } from './DraftSummaryDialog'
 
-function FactionNutshells({ players, classes, sessionId }) {
+function FactionNutshells({
+  players,
+  classes,
+  sessionId,
+  showTablePosition,
+  wasDrafted,
+}) {
   const { t } = useTranslation()
   const [nutshellFactionKey, setFactionNutshellKey] = useState(null)
 
-  return players.map(({ faction, playerName, color, speaker }) => {
+  const [draftSummaryDialogOpen, setDraftSummaryDialogOpen] = useState(false)
+
+  return players.map(({ faction, playerName, color, speaker }, index) => {
     const factionData = factions.getData(faction)
     const factionName = t(`factions.${faction}.name`)
 
@@ -34,6 +43,30 @@ function FactionNutshells({ players, classes, sessionId }) {
             {' '}
             (<Trans i18nKey="sessionView.r1Speaker" />)
           </em>
+        )}
+        {showTablePosition && (
+          <em>
+            {' '}
+            (
+            <Trans
+              i18nKey="sessionView.factionNutshell.tablePosition"
+              values={{ position: index + 1 }}
+            />
+            )
+          </em>
+        )}
+        {wasDrafted && (
+          <Tooltip
+            placement="top"
+            title={t('sessionView.factionNutshell.draftDetails')}
+          >
+            <IconButton
+              aria-label={t('sessionView.factionNutshell.draftDetails')}
+              onClick={() => setDraftSummaryDialogOpen(true)}
+            >
+              <Info />
+            </IconButton>
+          </Tooltip>
         )}
       </span>
     )
@@ -109,6 +142,10 @@ function FactionNutshells({ players, classes, sessionId }) {
         <FactionNutshell
           factionKey={nutshellFactionKey}
           onClose={() => setFactionNutshellKey(null)}
+        />
+        <DraftSummaryDialog
+          open={draftSummaryDialogOpen}
+          set={setDraftSummaryDialogOpen}
         />
       </>
     )

--- a/client/src/SessionView/Overview/Session.js
+++ b/client/src/SessionView/Overview/Session.js
@@ -107,6 +107,8 @@ export function Session({ editable, session, updateFactionPoints }) {
             classes={classes}
             players={session.players}
             sessionId={session.id}
+            showTablePosition={Boolean(session.setup.options?.tablePick)}
+            wasDrafted={session.setup.setupType === 'draft'}
           />
         </Grid>
       </HideInFullscreen>

--- a/client/src/SessionView/Timeline/Timeline.js
+++ b/client/src/SessionView/Timeline/Timeline.js
@@ -1,14 +1,7 @@
-import { useMemo, useCallback } from 'react'
+import { useCallback } from 'react'
 import clsx from 'clsx'
 import {
   Box,
-  Paper,
-  Table,
-  TableBody,
-  TableHead,
-  TableCell,
-  TableContainer,
-  TableRow,
   Typography,
   Link,
   List,
@@ -45,7 +38,7 @@ import useSmallViewport from '../../shared/useSmallViewport'
 import ScrollToBottom from '../../shared/ScrollToBottom'
 import Relic from '../../shared/Relic'
 import useInvalidateQueries from '../../useInvalidateQueries'
-import { MapPreview } from '../MapPreview'
+import { DraftSummaryTable } from '../components'
 
 import { Agenda } from './Agenda'
 import AddTimelineEvent from './AddTimelineEvent'
@@ -668,22 +661,6 @@ function SupportCreatorEvent() {
 }
 
 function DraftSummary({ payload, happenedAt, session }) {
-  const { t } = useTranslation()
-
-  const withTablePositions = Boolean(session.setup.options?.tablePick)
-  const showMap = withTablePositions && session.map
-  const picks = useMemo(() => {
-    if (withTablePositions) {
-      const memoized = [...payload.picks]
-
-      memoized.sort((a, b) => a.tablePosition - b.tablePosition)
-
-      return memoized
-    }
-
-    return payload.picks
-  }, [payload.picks, withTablePositions])
-
   return (
     <>
       <Ti4TimelineItem>
@@ -700,52 +677,12 @@ function DraftSummary({ payload, happenedAt, session }) {
           <Typography variant="h5">
             <Trans i18nKey="sessionTimeline.draftSummary.title" />
           </Typography>
-          <TableContainer component={Paper}>
-            <Table aria-label="simple table">
-              <TableHead>
-                <TableRow>
-                  <TableCell>
-                    <Trans i18nKey="general.labels.player" />
-                  </TableCell>
-                  <TableCell>
-                    <Trans i18nKey="general.labels.faction" />
-                  </TableCell>
-                  {withTablePositions && (
-                    <TableCell>
-                      <Trans i18nKey="general.labels.tablePosition" />
-                      {showMap && <MapPreview session={session} />}
-                    </TableCell>
-                  )}
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {picks.map((pick) => (
-                  <TableRow key={pick.playerName}>
-                    <TableCell component="th" scope="row">
-                      {pick.playerName}{' '}
-                      <em>
-                        {pick.playerName === payload.speaker
-                          ? `(${t('general.labels.speaker')})`
-                          : ''}
-                      </em>
-                    </TableCell>
-                    <TableCell>
-                      <FactionFlag
-                        disabled
-                        factionKey={pick.faction}
-                        height="3em"
-                        selected
-                        width="4.5em"
-                      />
-                    </TableCell>
-                    {withTablePositions && (
-                      <TableCell>P{pick.tablePosition + 1}</TableCell>
-                    )}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+          <DraftSummaryTable
+            map={session.map}
+            picks={payload.picks}
+            speaker={payload.speaker}
+            withTablePositions={Boolean(session.setup.options?.tablePick)}
+          />
         </Ti4TimelineContent>
       </Ti4TimelineItem>
       <SupportCreatorEvent />

--- a/client/src/SessionView/components/DraftSummaryTable.js
+++ b/client/src/SessionView/components/DraftSummaryTable.js
@@ -1,0 +1,92 @@
+import { useMemo } from 'react'
+import PropTypes from 'prop-types'
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableHead,
+  TableCell,
+  TableContainer,
+  TableRow,
+} from '@material-ui/core'
+import { Trans, useTranslation } from 'react-i18next'
+
+import { MapPreview } from './MapPreview'
+import FactionFlag from '../../shared/FactionFlag'
+
+export function DraftSummaryTable({ withTablePositions, map, picks, speaker }) {
+  const { t } = useTranslation()
+
+  const showMap = withTablePositions && map
+  const sortedPicks = useMemo(() => {
+    if (withTablePositions) {
+      const memoized = [...picks]
+
+      memoized.sort((a, b) => a.tablePosition - b.tablePosition)
+
+      return memoized
+    }
+
+    return picks
+  }, [picks, withTablePositions])
+
+  return (
+    <TableContainer component={Paper}>
+      <Table aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell>
+              <Trans i18nKey="general.labels.player" />
+            </TableCell>
+            <TableCell>
+              <Trans i18nKey="general.labels.faction" />
+            </TableCell>
+            {withTablePositions && (
+              <TableCell>
+                <Trans i18nKey="general.labels.tablePosition" />
+                {showMap && <MapPreview map={map} />}
+              </TableCell>
+            )}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedPicks.map((pick) => (
+            <TableRow key={pick.playerName}>
+              <TableCell component="th" scope="row">
+                {pick.playerName}{' '}
+                <em>
+                  {pick.playerName === speaker
+                    ? `(${t('general.labels.speaker')})`
+                    : ''}
+                </em>
+              </TableCell>
+              <TableCell>
+                <FactionFlag
+                  disabled
+                  factionKey={pick.faction}
+                  height="3em"
+                  selected
+                  width="4.5em"
+                />
+              </TableCell>
+              {withTablePositions && (
+                <TableCell>P{pick.tablePosition + 1}</TableCell>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  )
+}
+
+DraftSummaryTable.propTypes = {
+  picks: PropTypes.arrayOf(
+    PropTypes.shape({
+      faction: PropTypes.string.isRequired,
+      playerName: PropTypes.string.isRequired,
+      tablePosition: PropTypes.number,
+    }),
+  ).isRequired,
+  speaker: PropTypes.string.isRequired,
+}

--- a/client/src/SessionView/components/DraftSummaryTable.js
+++ b/client/src/SessionView/components/DraftSummaryTable.js
@@ -56,7 +56,7 @@ export function DraftSummaryTable({ withTablePositions, map, picks, speaker }) {
                 {pick.playerName}{' '}
                 <em>
                   {pick.playerName === speaker
-                    ? `(${t('general.labels.speaker')})`
+                    ? `(${t('sessionView.r1Speaker')})`
                     : ''}
                 </em>
               </TableCell>

--- a/client/src/SessionView/components/MapPreview.js
+++ b/client/src/SessionView/components/MapPreview.js
@@ -5,7 +5,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { Map as MapIcon } from '@material-ui/icons'
 import { Trans, useTranslation } from 'react-i18next'
 
-import useSmallViewport from '../shared/useSmallViewport'
+import useSmallViewport from '../../shared/useSmallViewport'
 
 const useStyles = makeStyles((theme) => ({
   bigDraftSummaryMap: {
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-export function MapPreview({ session, variant }) {
+export function MapPreview({ map, variant }) {
   const { t } = useTranslation()
   const small = useSmallViewport()
   const classes = useStyles()
@@ -34,17 +34,15 @@ export function MapPreview({ session, variant }) {
   return (
     <>
       <Button
-        disabled={!session.map}
+        disabled={!map}
         onClick={toggleMapDrawer}
         startIcon={<MapIcon />}
         variant={variant}
       >
-        {session.map && (
-          <Trans i18nKey="sessionTimeline.draftSummary.toggleMap" />
-        )}
-        {!session.map && <Trans i18nKey="sessionMap.none" />}
+        {map && <Trans i18nKey="sessionTimeline.draftSummary.toggleMap" />}
+        {!map && <Trans i18nKey="sessionMap.none" />}
       </Button>
-      {session.map && (
+      {map && (
         <Drawer anchor="left" onClose={toggleMapDrawer} open={mapDrawerOpen}>
           <Grid
             alignItems="center"
@@ -59,7 +57,7 @@ export function MapPreview({ session, variant }) {
                 className={clsx(classes.draftSummaryMap, {
                   [classes.bigDraftSummaryMap]: small,
                 })}
-                src={session.map}
+                src={map}
               />
             </Grid>
           </Grid>

--- a/client/src/SessionView/components/index.js
+++ b/client/src/SessionView/components/index.js
@@ -1,0 +1,2 @@
+export * from './DraftSummaryTable'
+export * from './MapPreview'

--- a/client/src/i18n/index.js
+++ b/client/src/i18n/index.js
@@ -151,6 +151,10 @@ const factory = (options = { debug: true }) =>
             },
             sessionView: {
               r1Speaker: 'R1 speaker',
+              factionNutshell: {
+                tablePosition: 'at table: P{{position}}',
+                draftDetails: 'draft details',
+              },
               lock: 'Prevent further editing',
               locked: 'Locked for editing',
               nav: {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9513,6 +9513,15 @@ prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-addr@~2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -9784,7 +9793,7 @@ react-i18next@^11.12.0:
     "@babel/runtime" "^7.14.5"
     html-parse-stringify "^3.0.1"
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
closes #200 

draft summary is now available from session nutshells

![draft-shortcut](https://user-images.githubusercontent.com/9142942/159905757-c45f5cca-5474-4373-87a9-8cf413e3dcb6.gif)
