### PR TITLE
fix: player stepper layout

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ Bear in mind that release notes before 2022-08-14 were compiled post-factum and 
 ## 2022-07-14
 - [feat] Added the ability to select speaker position in addition to faction and table position when drafting. [PR](https://github.com/paxmagnifica/ti4-companion/pull/255)
 - [feat] Added release notes and link to them in the app footer. [PR](https://github.com/paxmagnifica/ti4-companion/pull/256)
+- [fix] Fixed player order stepper on draft to not break layout and to scroll active picking player into view [issue](https://github.com/paxmagnifica/ti4-companion/issues/257)
 
 ## 2022-07-12
 - [feat] Added game version configuration when starting a session. Data on cheatsheets and in Knowledge Base is now contextual to the selected version (base, PoK, C2, C3). [PR](https://github.com/paxmagnifica/ti4-companion/pull/252)

--- a/client/src/SessionView/Overview/Drafting/PlayerOrderStepper.js
+++ b/client/src/SessionView/Overview/Drafting/PlayerOrderStepper.js
@@ -24,45 +24,47 @@ export function PlayerOrderStepper({ history, order, activePlayer, title }) {
       <Typography align="center" variant="h4">
         {title}
       </Typography>
-      <Stepper
-        activeStep={activePlayer}
-        alternativeLabel
-        className={classes.root}
-      >
-        {order.map((label, index) => (
-          <Step color="secondary">
-            <StepLabel
-              optional={
-                <Typography
-                  align="center"
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    height: '3em',
-                  }}
-                >
-                  {index === activePlayer ? (
-                    <ActiveIcon color="secondary" />
-                  ) : index < activePlayer ? (
-                    history[index] || <DoneIcon color="secondary" />
-                  ) : null}
-                </Typography>
-              }
-              StepIconComponent={PlayerIcon}
-              StepIconProps={{
-                className: clsx({ [classes.done]: index < activePlayer }),
-              }}
-            >
-              <Typography
-                className={clsx({ [classes.done]: index < activePlayer })}
+      <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+        <Stepper
+          activeStep={activePlayer}
+          alternativeLabel
+          className={classes.root}
+        >
+          {order.map((label, index) => (
+            <Step color="secondary">
+              <StepLabel
+                optional={
+                  <Typography
+                    align="center"
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      height: '3em',
+                    }}
+                  >
+                    {index === activePlayer ? (
+                      <ActiveIcon color="secondary" />
+                    ) : index < activePlayer ? (
+                      history[index] || <DoneIcon color="secondary" />
+                    ) : null}
+                  </Typography>
+                }
+                StepIconComponent={PlayerIcon}
+                StepIconProps={{
+                  className: clsx({ [classes.done]: index < activePlayer }),
+                }}
               >
-                {label}
-              </Typography>
-            </StepLabel>
-          </Step>
-        ))}
-      </Stepper>
+                <Typography
+                  className={clsx({ [classes.done]: index < activePlayer })}
+                >
+                  {label}
+                </Typography>
+              </StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+      </div>
     </>
   )
 }

--- a/client/src/SessionView/Overview/Drafting/PlayerOrderStepper.js
+++ b/client/src/SessionView/Overview/Drafting/PlayerOrderStepper.js
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import clsx from 'clsx'
 import { Typography, Stepper, Step, StepLabel } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
@@ -18,20 +19,39 @@ const useStepperStyles = makeStyles(() => ({
 
 export function PlayerOrderStepper({ history, order, activePlayer, title }) {
   const classes = useStepperStyles()
+  const firstStepRef = useRef(null)
+  const scrollContainerRef = useRef(null)
+
+  useEffect(() => {
+    if (!firstStepRef.current || !scrollContainerRef.current) {
+      return
+    }
+
+    const firstStepRect = firstStepRef.current.getBoundingClientRect()
+    const stepWidth = firstStepRect.width
+
+    scrollContainerRef.current.scroll((activePlayer - 1) * stepWidth, 0)
+  }, [activePlayer])
 
   return (
     <>
       <Typography align="center" variant="h4">
         {title}
       </Typography>
-      <div style={{ maxWidth: '100%', overflow: 'auto' }}>
+      <div
+        ref={scrollContainerRef}
+        style={{ maxWidth: '100%', overflow: 'auto' }}
+      >
         <Stepper
           activeStep={activePlayer}
           alternativeLabel
           className={classes.root}
         >
           {order.map((label, index) => (
-            <Step color="secondary">
+            <Step
+              ref={index === 0 ? firstStepRef : undefined}
+              color="secondary"
+            >
               <StepLabel
                 optional={
                   <Typography


### PR DESCRIPTION
closes #257 

- [x] fixed layout, made stepper scrollable
- [x] active player is scrolled into view

![image](https://user-images.githubusercontent.com/9142942/179061746-834aa188-2652-4dcc-aeab-15a0f14056eb.png)
