### PR TITLE
Meta title tag displays correct session details (#249)

### DIFF
--- a/client/src/SessionView/Overview/SessionNutshell.js
+++ b/client/src/SessionView/Overview/SessionNutshell.js
@@ -1,10 +1,23 @@
 import { Grid } from '@material-ui/core'
 
-import { Trans } from '../../i18n'
+import { useTranslation } from '../../i18n'
 import { useSessionContext } from '../useSessionContext'
+
+export function getSessionDetails(session, t) {
+  return `${
+    session.displayName &&
+    `${session.displayName}, ${t('playersCount', {
+      players: session.players?.length || session.draft?.players?.length,
+    })}, ${t('vpCount', { points: session.vpCount })}${
+      session.start &&
+      `, ${t('sessionView.overview.sessionStart', { when: session.start })}`
+    }`
+  }`
+}
 
 export function SessionNutshell() {
   const { session } = useSessionContext()
+  const { t } = useTranslation()
 
   return (
     <Grid
@@ -15,23 +28,7 @@ export function SessionNutshell() {
       styles={{ color: 'white' }}
     >
       <Grid item xs={12}>
-        {session.displayName && `${session.displayName}, `}
-        <Trans
-          i18nKey="playersCount"
-          values={{
-            players: session.players?.length || session.draft?.players?.length,
-          }}
-        />
-        , <Trans i18nKey="vpCount" values={{ points: session.vpCount }} />
-        {session.start && (
-          <>
-            {', '}
-            <Trans
-              i18nKey="sessionView.overview.sessionStart"
-              values={{ when: session.start }}
-            />
-          </>
-        )}
+        {getSessionDetails(session, t)}
       </Grid>
     </Grid>
   )

--- a/client/src/SessionView/SessionView.js
+++ b/client/src/SessionView/SessionView.js
@@ -10,6 +10,7 @@ import { SESSION_VIEW_ROUTES } from '../shared/constants'
 import { TogglePlasticColorsButton } from '../shared/plasticColors'
 
 import { useSessionContext } from './useSessionContext'
+import { useTranslation } from '../i18n'
 import { Overview } from './Overview'
 import ShareButton from './ShareButton'
 import { EditButton } from './Edit'
@@ -18,6 +19,7 @@ import SessionNavigation from './SessionNavigation'
 import DetailsForm from './DetailsForm'
 import LockForEdit from './LockForEdit'
 import { Timeline } from './Timeline'
+import { getSessionDetails } from './Overview/SessionNutshell'
 
 const useStyles = makeStyles({
   header: {
@@ -32,6 +34,7 @@ export function SessionView({
   updateFactionPoints,
 }) {
   const classes = useStyles()
+  const { t } = useTranslation()
 
   const sortedPoints = [...session.points]
   sortedPoints.sort((a, b) => b.points - a.points)
@@ -50,7 +53,7 @@ export function SessionView({
   return (
     <>
       <Helmet>
-        <title>{`TI4 Companion session- ${session.factions.length} players - 10VP`}</title>
+        <title>{`TI4 Companion - ${getSessionDetails(session, t)}`}</title>
         <meta
           content={sortedPoints
             .map(
@@ -61,10 +64,7 @@ export function SessionView({
           name="description"
         />
 
-        <meta
-          content={`TI4 Companion session - ${session.factions.length} players - 10VP`}
-          property="og:title"
-        />
+        <meta content={getSessionDetails(session, t)} property="og:title" />
         <meta
           content={sortedPoints
             .map(


### PR DESCRIPTION
Solves https://github.com/paxmagnifica/ti4-companion/issues/249.

There is the same logic responsible for preparing the text for meta tag and for this piece of title in dashboard, hope it won't require any additional styles or something. 