### PR TITLE
326 add backend validation for katowice draft

### DIFF
--- a/client/src/i18n/index.js
+++ b/client/src/i18n/index.js
@@ -113,8 +113,27 @@ export const factory = (options = { debug: true }) =>
               401: 'Unauthorized',
               404: 'The item you are looking for was not found',
               500: 'Something went wrong on our side, try again in a moment',
+              something_went_wrong:
+                'Something went wrong, try again in a moment',
               stale_state_event:
                 'You are missing some updates, please refresh the page and retry. If the problem persists please contact support.',
+              pick_bans_done: 'Picks and bans are already over.',
+              faction_already_used: 'This faction was already banned or picked',
+              nominations_done: 'Nominations are already over',
+              already_nominated_confirmed: 'This faction was already used',
+              confirming_without_nomination:
+                'Factions need to be nominated before they can be confirmed',
+              draft_already_done:
+                'Draft is already over, have fun in the game!',
+              draft_duplicating_action:
+                'You can only pick one of each (faction, initiative, table position etc.)',
+              faction_not_available: 'This faction is not in the draft pool',
+              faction_already_picked:
+                'This faction has already been picked by somebody else',
+              initiative_already_picked:
+                'This initiative has already been picked by somebody else',
+              table_position_already_picked:
+                'This position at the table has already been picked by somebody else',
             },
             components: {
               agenda: {

--- a/server/Controllers/EventsController.cs
+++ b/server/Controllers/EventsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
+using Server.Domain.Exceptions;
 using Server.Infra;
 using System;
 using System.Threading.Tasks;
@@ -50,6 +51,14 @@ namespace Server.Controllers
             {
                 this.logger.LogWarning(exception.Message);
                 return new NotFoundResult();
+            }
+            catch (Ti4CompanionDomainException exception)
+            {
+                this.logger.LogWarning(exception.Message);
+                return new BadRequestObjectResult(new
+                {
+                    tiCompanionError = exception.ErrorKey,
+                });
             }
         }
     }

--- a/server/Domain/Exceptions/ConflictException.cs
+++ b/server/Domain/Exceptions/ConflictException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Server.Domain.Exceptions
+{
+    [Serializable]
+    public class ConflictException : Ti4CompanionDomainException
+    {
+        public ConflictException()
+            : base("Cannot take the action due to conflicting state")
+        {
+        }
+    }
+}

--- a/server/Domain/Exceptions/ConflictException.cs
+++ b/server/Domain/Exceptions/ConflictException.cs
@@ -5,8 +5,8 @@ namespace Server.Domain.Exceptions
     [Serializable]
     public class ConflictException : Ti4CompanionDomainException
     {
-        public ConflictException()
-            : base("Cannot take the action due to conflicting state")
+        public ConflictException(string key = null)
+            : base("Cannot take the action due to conflicting state", key)
         {
         }
     }

--- a/server/Domain/Exceptions/Ti4CompanionDomainException.cs
+++ b/server/Domain/Exceptions/Ti4CompanionDomainException.cs
@@ -5,9 +5,12 @@ namespace Server.Domain.Exceptions
     [Serializable]
     public class Ti4CompanionDomainException : Exception
     {
-        public Ti4CompanionDomainException(string message)
+        public Ti4CompanionDomainException(string message, string key = null)
             : base(message)
         {
+            this.ErrorKey = key ?? "something_went_wrong";
         }
+
+        public string ErrorKey { get; internal set; }
     }
 }

--- a/server/Domain/Katowice/Constants.cs
+++ b/server/Domain/Katowice/Constants.cs
@@ -7,6 +7,8 @@ namespace Server.Domain.Katowice
         internal static readonly string NominationsPhase = "nominations";
         internal static readonly string BanAction = "ban";
         internal static readonly string PickAction = "pick";
+        internal static readonly string NominateAction = "nominate";
+        internal static readonly string ConfirmAction = "confirm";
         internal static readonly string DraftPhase = "draft";
         internal static readonly string InitiativeAction = "initiative";
         internal static readonly string FactionAction = "faction";

--- a/server/Domain/Katowice/Handlers/DraftPick.cs
+++ b/server/Domain/Katowice/Handlers/DraftPick.cs
@@ -1,4 +1,7 @@
 using Newtonsoft.Json;
+using Server.Domain.Exceptions;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -22,14 +25,50 @@ namespace Server.Domain.Katowice
                 // error
             }
 
-            // TODO checks:
-            // check if action is the same as current player
-            // check if playerindex is the same as current player
-            // check if confirming without nomination
-            // check if not duplicated (nominating nominated/confirmed or confirming confirmed)
+            var gameStartEvent = session.GetGameStartedInfo();
+            var draftPickPlayerIndexes = new List<int>();
+            draftPickPlayerIndexes.AddRange(gameStartEvent.RandomPlayerOrder);
+            draftPickPlayerIndexes.AddRange(gameStartEvent.RandomPlayerOrder.Reverse());
+            draftPickPlayerIndexes.AddRange(gameStartEvent.RandomPlayerOrder);
+
+            var draftPickAlreadyDone = session.Events.Count(ge => ge.EventType == nameof(DraftPick)) == gameStartEvent.RandomPlayerOrder.Length * 3;
+
+            if (draftPickAlreadyDone)
+            {
+                throw new ConflictException();
+            }
+
+            var draftPickEventPayloads = session.Events.Where(ev => ev.EventType == nameof(DraftPick));
+            var draftPickEventsWithPlayerIndexes = draftPickEventPayloads.Select((dpe, index) => Tuple.Create(draftPickPlayerIndexes.ElementAt(index), dpe));
+            var currentPlayerIndex = draftPickPlayerIndexes.ElementAt(draftPickEventsWithPlayerIndexes.Count());
+
+            var previousPlayerPickPayloads = draftPickEventsWithPlayerIndexes.Where(dpei => dpei.Item1 == currentPlayerIndex).Select(dpei => GetPayload(dpei.Item2));
+
+            var currentPayload = GetPayload(gameEvent);
+            var playerDuplicatingAction = previousPlayerPickPayloads.Any(pppp => pppp.Action == currentPayload.Action);
+
+            if (playerDuplicatingAction)
+            {
+                throw new ConflictException();
+            }
+
+            if (currentPayload.Action == Constants.FactionAction)
+            {
+                this.ValidateFactionPick(session.Events, currentPayload);
+            }
+
+            if (currentPayload.Action == Constants.InitiativeAction)
+            {
+                this.ValidateInitiativeAction(session.Events, currentPayload);
+            }
+
+            if (currentPayload.Action == Constants.TablePositionAction)
+            {
+                this.ValidateTablePositionAction(session.Events, currentPayload);
+            }
+
             session.Events.Add(gameEvent);
 
-            var gameStartEvent = GameStarted.GetPayload(session.Events.First(ev => ev.EventType == nameof(GameStarted)));
             if (session.Events.Count(ge => ge.EventType == nameof(DraftPick)) == gameStartEvent.RandomPlayerOrder.Length * 3)
             {
                 var draftPickPayloads = session.Events.Where(ge => ge.EventType == nameof(DraftPick)).Select(ge => DraftPick.GetPayload(ge));
@@ -56,6 +95,46 @@ namespace Server.Domain.Katowice
         internal static DraftPickPayload GetPayload(GameEvent gameEvent)
         {
             return GetPayload(gameEvent.SerializedPayload);
+        }
+
+        private void ValidateFactionPick(List<GameEvent> events, DraftPickPayload currentPayload)
+        {
+            var factionsPickedIntoPool = events.Where(ev => ev.EventType == nameof(PickBan) && PickBan.GetPayload(ev).Action == Constants.PickAction).Select(PickBan.GetPayload).Select(p => p.Faction);
+            var factionsConfirmedIntoPool = events.Where(ev => ev.EventType == nameof(Nomination) && Nomination.GetPayload(ev).Action == Constants.ConfirmAction).Select(Nomination.GetPayload).Select(p => p.Faction);
+
+            var pickedFactions = events.Where(ev => ev.EventType == nameof(DraftPick) && GetPayload(ev).Action == Constants.FactionAction).Select(DraftPick.GetPayload).Select(p => p.Choice);
+            var factionAlreadyPicked = pickedFactions.Contains(currentPayload.Choice);
+
+            var pickedAvailableFaction = !factionAlreadyPicked && (factionsPickedIntoPool.Contains(currentPayload.Choice) || factionsConfirmedIntoPool.Contains(currentPayload.Choice));
+
+            if (!pickedAvailableFaction)
+            {
+                throw new ConflictException();
+            }
+        }
+
+        private void ValidateInitiativeAction(List<GameEvent> events, DraftPickPayload currentPayload)
+        {
+            var takenInitiative = events.Where(ev => ev.EventType == nameof(DraftPick) && GetPayload(ev).Action == Constants.InitiativeAction).Select(DraftPick.GetPayload).Select(p => p.Choice);
+
+            var validChoice = !takenInitiative.Contains(currentPayload.Choice);
+
+            if (!validChoice)
+            {
+                throw new ConflictException();
+            }
+        }
+
+        private void ValidateTablePositionAction(List<GameEvent> events, DraftPickPayload currentPayload)
+        {
+            var takenTablePositions = events.Where(ev => ev.EventType == nameof(DraftPick) && GetPayload(ev).Action == Constants.TablePositionAction).Select(DraftPick.GetPayload).Select(p => p.Choice);
+
+            var validChoice = !takenTablePositions.Contains(currentPayload.Choice);
+
+            if (!validChoice)
+            {
+                throw new ConflictException();
+            }
         }
 
         internal static DraftPickPayload GetPayload(string serializedPayload)

--- a/server/Domain/Katowice/Handlers/Nomination.cs
+++ b/server/Domain/Katowice/Handlers/Nomination.cs
@@ -30,7 +30,7 @@ namespace Server.Domain.Katowice
 
             if (nominationEvents.Count() == expectedNominationEventsCount)
             {
-                throw new ConflictException();
+                throw new ConflictException("nominations_done");
             }
 
             var eventWhereFactionUsed = session.Events.LastOrDefault(ev => GetPayload(ev).Faction == currentEventPayload.Faction);
@@ -41,13 +41,13 @@ namespace Server.Domain.Katowice
             var duplicatingAction = payloadWhereFactionUsed != null && !confirmingNomination;
             if (duplicatingAction)
             {
-                throw new ConflictException();
+                throw new ConflictException("already_nominated_confirmed");
             }
 
             var confirmingWithoutNomination = currentEventPayload.Action == Constants.ConfirmAction && payloadWhereFactionUsed == null;
             if (confirmingWithoutNomination)
             {
-                throw new ConflictException();
+                throw new ConflictException("confirming_without_nomination");
             }
 
             session.Events.Add(gameEvent);

--- a/server/Domain/Katowice/Handlers/Nomination.cs
+++ b/server/Domain/Katowice/Handlers/Nomination.cs
@@ -1,4 +1,6 @@
 using Newtonsoft.Json;
+using Server.Domain.Exceptions;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Server.Domain.Katowice
@@ -21,11 +23,33 @@ namespace Server.Domain.Katowice
                 // error
             }
 
-            // TODO checks:
-            // check if action is the same as current player
-            // check if playerindex is the same as current player
-            // check if confirming without nomination
-            // check if not duplicated (nominating nominated/confirmed or confirming confirmed)
+            var currentEventPayload = GetPayload(gameEvent);
+
+            var nominationEvents = session.Events.Where(ev => ev.EventType == nameof(Nomination));
+            var expectedNominationEventsCount = session.GetGameStartedInfo().RandomPlayerOrder.Length * 2;
+
+            if (nominationEvents.Count() == expectedNominationEventsCount)
+            {
+                throw new ConflictException();
+            }
+
+            var eventWhereFactionUsed = session.Events.LastOrDefault(ev => GetPayload(ev).Faction == currentEventPayload.Faction);
+            var payloadWhereFactionUsed = eventWhereFactionUsed == null && eventWhereFactionUsed.EventType != nameof(Nomination) ? null : GetPayload(eventWhereFactionUsed);
+
+            var confirmingNomination = currentEventPayload.Action == Constants.ConfirmAction && payloadWhereFactionUsed?.Action == Constants.NominateAction;
+
+            var duplicatingAction = payloadWhereFactionUsed != null && !confirmingNomination;
+            if (duplicatingAction)
+            {
+                throw new ConflictException();
+            }
+
+            var confirmingWithoutNomination = currentEventPayload.Action == Constants.ConfirmAction && payloadWhereFactionUsed == null;
+            if (confirmingWithoutNomination)
+            {
+                throw new ConflictException();
+            }
+
             session.Events.Add(gameEvent);
 
             this.repository.UpdateSession(session);

--- a/server/Domain/Katowice/Handlers/PickBan.cs
+++ b/server/Domain/Katowice/Handlers/PickBan.cs
@@ -24,10 +24,15 @@ namespace Server.Domain.Katowice
             }
 
             var currentEventPayload = GetPayload(gameEvent);
-
             var pickBanEvents = session.Events.Where(ev => ev.EventType == nameof(PickBan));
-            var factionAlreadyUsed = session.Events.Any(ev => GetPayload(ev).Faction == currentEventPayload.Faction);
+            var expectedNumberOfPickBanEvents = session.GetGameStartedInfo().RandomPlayerOrder.Length * 2;
 
+            if (pickBanEvents.Count() == expectedNumberOfPickBanEvents)
+            {
+                throw new ConflictException();
+            }
+
+            var factionAlreadyUsed = pickBanEvents.Any(ev => GetPayload(ev).Faction == currentEventPayload.Faction);
             if (factionAlreadyUsed)
             {
                 throw new ConflictException();
@@ -36,6 +41,7 @@ namespace Server.Domain.Katowice
             // TODO checks:
             // check if action is the same as current player
             // check if playerindex is the same as current player
+            // should not accept nominations / confirmations after all done
             session.Events.Add(gameEvent);
 
             this.repository.UpdateSession(session);

--- a/server/Domain/Katowice/Handlers/PickBan.cs
+++ b/server/Domain/Katowice/Handlers/PickBan.cs
@@ -41,7 +41,6 @@ namespace Server.Domain.Katowice
             // TODO checks:
             // check if action is the same as current player
             // check if playerindex is the same as current player
-            // should not accept nominations / confirmations after all done
             session.Events.Add(gameEvent);
 
             this.repository.UpdateSession(session);

--- a/server/Domain/Katowice/Handlers/PickBan.cs
+++ b/server/Domain/Katowice/Handlers/PickBan.cs
@@ -1,4 +1,6 @@
 using Newtonsoft.Json;
+using Server.Domain.Exceptions;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Server.Domain.Katowice
@@ -21,10 +23,19 @@ namespace Server.Domain.Katowice
                 // error
             }
 
+            var currentEventPayload = GetPayload(gameEvent);
+
+            var pickBanEvents = session.Events.Where(ev => ev.EventType == nameof(PickBan));
+            var factionAlreadyUsed = session.Events.Any(ev => GetPayload(ev).Faction == currentEventPayload.Faction);
+
+            if (factionAlreadyUsed)
+            {
+                throw new ConflictException();
+            }
+
             // TODO checks:
             // check if action is the same as current player
             // check if playerindex is the same as current player
-            // check if not duplicated
             session.Events.Add(gameEvent);
 
             this.repository.UpdateSession(session);

--- a/server/Domain/Katowice/Handlers/PickBan.cs
+++ b/server/Domain/Katowice/Handlers/PickBan.cs
@@ -29,18 +29,15 @@ namespace Server.Domain.Katowice
 
             if (pickBanEvents.Count() == expectedNumberOfPickBanEvents)
             {
-                throw new ConflictException();
+                throw new ConflictException("pick_bans_done");
             }
 
             var factionAlreadyUsed = pickBanEvents.Any(ev => GetPayload(ev).Faction == currentEventPayload.Faction);
             if (factionAlreadyUsed)
             {
-                throw new ConflictException();
+                throw new ConflictException("faction_already_used");
             }
 
-            // TODO checks:
-            // check if action is the same as current player
-            // check if playerindex is the same as current player
             session.Events.Add(gameEvent);
 
             this.repository.UpdateSession(session);

--- a/serverTests/Katowice/DraftPick.cs
+++ b/serverTests/Katowice/DraftPick.cs
@@ -4,8 +4,8 @@ using Newtonsoft.Json.Serialization;
 using NSubstitute;
 using NUnit.Framework;
 using Server.Domain;
+using Server.Domain.Exceptions;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -64,6 +64,318 @@ namespace ServerTests.Katowice
             payload.Factions.Should().BeEquivalentTo(expectedFactions);
             payload.TablePositions.Should().BeEquivalentTo(expectedTablePositions);
             payload.Initiative.Should().BeEquivalentTo(expectedInitiative);
+        }
+
+        [Test]
+        public async Task ShouldNotAllowDraftPickEventAfterAllDraftPickEvents()
+        {
+            // given
+            var sessionWithAllDraftDone = Data.GetFullyDraftedSession();
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(sessionWithAllDraftDone);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "faction",
+                    Choice = "The_Argent_Flight",
+                    PlayerIndex = 4,
+                }),
+            };
+
+            // when
+            Func<Task> addingTooManyDraftPicks = () => draftPickHandler.Handle(given);
+
+            // then
+            await addingTooManyDraftPicks.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersTheSamePickTwice_Initiative()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+            var eventsThatAllowPlayer2SecondInitiativePick = Data.GetFullDraft().Item2.Take(11);
+            session.Events.AddRange(eventsThatAllowPlayer2SecondInitiativePick);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "initiative",
+                    Choice = "2",
+                }),
+            };
+
+            // when
+            Func<Task> pickingInitiativeSecondTimeAsPlayer2 = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingInitiativeSecondTimeAsPlayer2.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersTheSamePickTwice_TablePosition()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+            var eventsThatAllowPlayer4SecondTablePositionPick = Data.GetFullDraft().Item2.Take(6);
+            session.Events.AddRange(eventsThatAllowPlayer4SecondTablePositionPick);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "tablePosition",
+                    Choice = "4",
+                }),
+            };
+
+            // when
+            Func<Task> pickingTablePositionSecondTimeAsPlayer4 = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingTablePositionSecondTimeAsPlayer4.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersTheSamePickTwice_Faction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+            var eventsThatAllowPlayer1SecondFactionPick = Data.GetFullDraft().Item2.Take(8);
+            session.Events.AddRange(eventsThatAllowPlayer1SecondFactionPick);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "faction",
+                    Choice = "The_Embers_of_Muaat",
+                }),
+            };
+
+            // when
+            Func<Task> pickingFactionSecondTimeAsPlayer1 = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingFactionSecondTimeAsPlayer1.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersToPickBannedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "faction",
+                    Choice = "The_Naalu_Collective",
+                }),
+            };
+
+            // when
+            Func<Task> pickingBannedFaction = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingBannedFaction.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersToPickNominatedUnconfirmedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "faction",
+                    Choice = "The_Federation_of_Sol",
+                }),
+            };
+
+            // when
+            Func<Task> pickingNominatedUnconfirmedFaction = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingNominatedUnconfirmedFaction.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersToPickIgnoredFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "faction",
+                    Choice = "The_VuilRaith_Cabal",
+                }),
+            };
+
+            // when
+            Func<Task> pickingFactionThatNobodyCaredAbout = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingFactionThatNobodyCaredAbout.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersToPickFactionAlreadyPickedByAnotherPlayer()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "faction",
+                    Choice = "The_Arborec",
+                }),
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "faction",
+                    Choice = "The_Arborec",
+                }),
+            };
+
+            // when
+            Func<Task> pickingFactionSomebodyAlreadyPicked = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingFactionSomebodyAlreadyPicked.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersToPickInitiativeAlreadyPicked()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "initiative",
+                    Choice = "1",
+                }),
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "initiative",
+                    Choice = "1",
+                }),
+            };
+
+            // when
+            Func<Task> pickingTheSameInitiativeAsSomebodyElse = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingTheSameInitiativeAsSomebodyElse.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPlayersToPickTablePositionAlreadyPicked()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "tablePosition",
+                    Choice = "1",
+                }),
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var draftPickHandler = new Server.Domain.Katowice.DraftPick(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.DraftPick),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.DraftPickPayload
+                {
+                    Action = "tablePosition",
+                    Choice = "1",
+                }),
+            };
+
+            // when
+            Func<Task> pickingTheSameTablePositionAsSomebodyElse = () => draftPickHandler.Handle(given);
+
+            // then
+            await pickingTheSameTablePositionAsSomebodyElse.Should().ThrowAsync<ConflictException>();
         }
     }
 }

--- a/serverTests/Katowice/Nomination.cs
+++ b/serverTests/Katowice/Nomination.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NSubstitute;
+using NUnit.Framework;
+using Server.Domain;
+using Server.Domain.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ServerTests.Katowice
+{
+    public class Nomination
+    {
+        public Nomination()
+        {
+            this.Repository = Substitute.For<IRepository>();
+        }
+
+        private JsonSerializerSettings SerializerSettings
+        {
+            get
+            {
+                var serializerSettings = new JsonSerializerSettings();
+                serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                return serializerSettings;
+            }
+        }
+
+        private IRepository Repository { get; set; }
+
+        [Test]
+        public async Task ShouldNotAllowNominatingAlreadyNominatedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "nominate",
+                    Faction = "The_Argent_Flight",
+                }),
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var nomination = new Server.Domain.Katowice.Nomination(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "nominate",
+                    Faction = "The_Argent_Flight",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => nomination.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldAllowConfirmingPreviouslyNominatedFAction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "nominate",
+                    Faction = "The_Argent_Flight",
+                }),
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var nomination = new Server.Domain.Katowice.Nomination(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "confirm",
+                    Faction = "The_Argent_Flight",
+                }),
+            };
+
+            // when
+            await nomination.Handle(given);
+
+            // then
+            session.Events.Last().Should().Be(given);
+        }
+
+        [Test]
+        public async Task ShouldNotAllowConfirmingPreviouslyConfirmedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "nominate",
+                    Faction = "The_Argent_Flight",
+                }),
+            });
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "confirm",
+                    Faction = "The_Argent_Flight",
+                }),
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var nomination = new Server.Domain.Katowice.Nomination(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "confirm",
+                    Faction = "The_Argent_Flight",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => nomination.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowConfirmingFactionThatWasNotNominated()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "nominate",
+                    Faction = "The_Argent_Flight",
+                }),
+            });
+            session.Events.Add(new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "confirm",
+                    Faction = "The_Argent_Flight",
+                }),
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var nomination = new Server.Domain.Katowice.Nomination(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "confirm",
+                    Faction = "The_Arborec",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => nomination.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowConfirmingOrNominatingAfterAllNominationsConfirmationsAreDone()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+            session.Events.AddRange(Data.GetAllNominations().Item2);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var nomination = new Server.Domain.Katowice.Nomination(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "confirm",
+                    Faction = "The_Federation_of_Sol",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => nomination.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowNominatingBannedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var nomination = new Server.Domain.Katowice.Nomination(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "nominate",
+                    Faction = "The_Naalu_Collective",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => nomination.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowNominatingPickedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var nomination = new Server.Domain.Katowice.Nomination(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.Nomination),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.NominationPayload
+                {
+                    Action = "nominate",
+                    Faction = "The_Arborec",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => nomination.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+    }
+}

--- a/serverTests/Katowice/PickBan.cs
+++ b/serverTests/Katowice/PickBan.cs
@@ -1,0 +1,186 @@
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NSubstitute;
+using NUnit.Framework;
+using Server.Domain;
+using Server.Domain.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ServerTests.Katowice
+{
+    public class PickBan
+    {
+        public PickBan()
+        {
+            this.Repository = Substitute.For<IRepository>();
+        }
+
+        private JsonSerializerSettings SerializerSettings
+        {
+            get
+            {
+                var serializerSettings = new JsonSerializerSettings();
+                serializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                return serializerSettings;
+            }
+        }
+
+        private IRepository Repository { get; set; }
+
+        [Test]
+        public async Task ShouldNotAllowPickingAlreadyBannedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(new List<GameEvent>
+            {
+                new GameEvent
+                {
+                    EventType = nameof(Server.Domain.Katowice.PickBan),
+                    SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                    {
+                        Action = "ban",
+                        Faction = "The_Argent_Flight",
+                    }),
+                },
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var pickBan = new Server.Domain.Katowice.PickBan(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.PickBan),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                {
+                    Action = "pick",
+                    Faction = "The_Argent_Flight",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => pickBan.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowPickingAlreadyPickedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(new List<GameEvent>
+            {
+                new GameEvent
+                {
+                    EventType = nameof(Server.Domain.Katowice.PickBan),
+                    SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                    {
+                        Action = "pick",
+                        Faction = "The_Argent_Flight",
+                    }),
+                },
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var pickBan = new Server.Domain.Katowice.PickBan(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.PickBan),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                {
+                    Action = "pick",
+                    Faction = "The_Argent_Flight",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => pickBan.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowBanningAlreadyBannedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(new List<GameEvent>
+            {
+                new GameEvent
+                {
+                    EventType = nameof(Server.Domain.Katowice.PickBan),
+                    SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                    {
+                        Action = "ban",
+                        Faction = "The_Argent_Flight",
+                    }),
+                },
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var pickBan = new Server.Domain.Katowice.PickBan(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.PickBan),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                {
+                    Action = "ban",
+                    Faction = "The_Argent_Flight",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => pickBan.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowBanningAlreadyPickedFaction()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(new List<GameEvent>
+            {
+                new GameEvent
+                {
+                    EventType = nameof(Server.Domain.Katowice.PickBan),
+                    SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                    {
+                        Action = "pick",
+                        Faction = "The_Argent_Flight",
+                    }),
+                },
+            });
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var pickBan = new Server.Domain.Katowice.PickBan(this.Repository);
+            var given = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.PickBan),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                {
+                    Action = "ban",
+                    Faction = "The_Argent_Flight",
+                }),
+            };
+
+            // when
+            Func<Task> act = () => pickBan.Handle(given);
+
+            // then
+            await act.Should().ThrowAsync<ConflictException>();
+        }
+    }
+}

--- a/serverTests/Katowice/PickBan.cs
+++ b/serverTests/Katowice/PickBan.cs
@@ -7,7 +7,6 @@ using Server.Domain;
 using Server.Domain.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace ServerTests.Katowice
@@ -181,6 +180,44 @@ namespace ServerTests.Katowice
 
             // then
             await act.Should().ThrowAsync<ConflictException>();
+        }
+
+        [Test]
+        public async Task ShouldNotAllowBanningPickingAfterAllPicksAndBans()
+        {
+            // given
+            var session = Data.GetEmptySession();
+            session.Events.AddRange(Data.GetAllPickBans().Item2);
+
+            this.Repository.GetByIdWithEvents(Arg.Any<Guid>()).Returns(session);
+
+            var pickBan = new Server.Domain.Katowice.PickBan(this.Repository);
+            var givenBan = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.PickBan),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                {
+                    Action = "ban",
+                    Faction = "The_Naaz__Rokha_Alliance",
+                }),
+            };
+            var givenPick = new GameEvent
+            {
+                EventType = nameof(Server.Domain.Katowice.PickBan),
+                SerializedPayload = JsonConvert.SerializeObject(new Server.Domain.Katowice.PickBanPayload
+                {
+                    Action = "pick",
+                    Faction = "The_Naaz__Rokha_Alliance",
+                }),
+            };
+
+            // when
+            Func<Task> banning = () => pickBan.Handle(givenBan);
+            Func<Task> picking = () => pickBan.Handle(givenPick);
+
+            // then
+            await banning.Should().ThrowAsync<ConflictException>();
+            await picking.Should().ThrowAsync<ConflictException>();
         }
     }
 }


### PR DESCRIPTION
all actions are now validated against draft state (disallowing picking faction multiple times, picking factions that are not in the pool etc - see the tests for all business rules)